### PR TITLE
ci: add build-frontend workflow for EMS frontend

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,52 @@
+name: Build EMS Frontend
+
+on: 
+    workflow_dispatch:
+    pull_request:
+      branches: [ main ]
+      paths:
+        - 'ems-frontend/src/**'
+        - 'ems-frontend/package*.json'
+        - 'ems-frontend/*.html'
+        - 'ems-frontend/*.js'
+        - '.github/workflows/build-frontend.yml'
+    push:
+      branches: [ main ]
+      paths:
+        - 'ems-frontend/src/**'
+        - 'ems-frontend/package*.json'
+        - 'ems-frontend/*.html'
+        - 'ems-frontend/*.js'
+        - '.github/workflows/build-frontend.yml'
+
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up the Node dependencies caching
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - name: Install Node dependencies
+        working-directory: ./ems-frontend
+        run: npm install
+
+      - name: Build the frontend
+        working-directory: ./ems-frontend
+        run: npm run build
+
+      - name: Upload the build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ems-frontend-artifact
+          path: ./ems-frontend/dist/


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the build process for the EMS frontend. The workflow triggers on pull requests and pushes to the main branch, specifically when changes are made to frontend-related files. It sets up Node.js, caches dependencies, installs required packages, builds the frontend, and uploads the build artifact as part of the CI process.

- Closes #27 