### PR TITLE
build: update Spring Boot parent version to 3.4.4

### DIFF
--- a/ems-backend/pom.xml
+++ b/ems-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.3</version>
+		<version>3.4.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>net.javaguides</groupId>


### PR DESCRIPTION
This change updates the Spring Boot parent version to 3.4.4 to leverage the latest features, bug fixes, and improvements provided by the newer version.

- Fixes #34 