### PR TITLE
build: add PostgreSQL dependency to pom.xml

### DIFF
--- a/ems-backend/pom.xml
+++ b/ems-backend/pom.xml
@@ -54,6 +54,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This commit adds the PostgreSQL dependency to the project's pom.xml file to enable database connectivity for the application.

- Closes #36 